### PR TITLE
add next.config to all next.js docs

### DIFF
--- a/guides/nextjs.mdx
+++ b/guides/nextjs.mdx
@@ -48,7 +48,21 @@ Get [Laminar project API key](https://docs.lmnr.ai/tracing/introduction#2-initia
 Get [OpenAI API key](https://platform.openai.com/api-keys)
 
 </Step>
+<Step title = "Update next.config.ts">
 
+Add the following to your `next.config.ts` file:
+
+```javascript next.config.ts
+const nextConfig = {
+  serverExternalPackages: ['@lmnr-ai/lmnr'],
+};
+
+export default nextConfig;
+```
+
+This is because Laminar depends on OpenTelemetry, which uses some Node.js-specific functionality, and we need to inform Next.js about it. Learn more in the [Next.js docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages).
+
+</Step>
 <Step title="Project Structure">
 
 The project has the following structure:

--- a/tracing/integrations/nextjs.mdx
+++ b/tracing/integrations/nextjs.mdx
@@ -19,7 +19,22 @@ Also see the [Next.js guide](/guides/nextjs) for a step-by-step guide with a sma
 npm add @lmnr-ai/lmnr
 ```
 
-### 2. Initialize Laminar
+### 2. Update your next.config.ts
+
+Add the following to your `next.config.ts` file:
+
+```javascript next.config.ts
+const nextConfig = {
+  serverExternalPackages: ['@lmnr-ai/lmnr'],
+};
+
+export default nextConfig;
+```
+
+This is because Laminar depends on OpenTelemetry, which uses some Node.js-specific functionality, and we need to inform Next.js about it. Learn more in the [Next.js docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages).
+
+
+### 3. Initialize Laminar
 
 To instrument your entire Next.js app, place Laminar initialization in `instrumentation.{ts,js}` file. Learn more about `instrumentation.{ts,js}` [here](https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation).
 
@@ -53,4 +68,3 @@ module.exports = {
     experimental: { instrumentationHook: true }
 };
 ```
-

--- a/tracing/integrations/vercel-ai-sdk.mdx
+++ b/tracing/integrations/vercel-ai-sdk.mdx
@@ -11,6 +11,49 @@ Laminar tracing is based on OpenTelemetry, so it is fully compatible with Vercel
 <Step title="Get your project API key">
 <GetProjectApiKey />
 </Step>
+<Step title="Initialize Laminar">
+<Tabs>
+<Tab title="Next.js">
+In Next.js, place `Laminar.initialize` in the `instrumentation.ts` file.
+
+```typescript {3-4, 6-8} instrumentation.ts
+export async function register() {
+  // prevent this from running in the edge runtime
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { Laminar } = await import('@lmnr-ai/lmnr');
+
+    Laminar.initialize({
+      projectApiKey: process.env.LMNR_API_KEY,
+    });
+  }
+}
+```
+
+You will also need to update your `next.config.ts` file to include the `serverExternalPackages` option.
+
+```typescript next.config.ts
+const nextConfig = {
+  serverExternalPackages: ['@lmnr-ai/lmnr'],
+};
+```
+
+This is because Laminar depends on OpenTelemetry, which uses some Node.js-specific functionality, and we need to inform Next.js about it. Learn more in the [Next.js docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages).
+</Tab>
+<Tab title="Node.js">
+In Node.js, place `Laminar.initialize` in the entry point to your application.
+
+This must be done once, in an entry point of your application after any other tracing SDK initialization.
+
+```javascript
+import { Laminar } from '@lmnr-ai/lmnr';
+
+Laminar.initialize({
+  projectApiKey: process.env.LMNR_API_KEY,
+});
+```
+</Tab>
+</Tabs>
+</Step>
 <Step title="Update your AI SDK calls">
 
 We need to pass the Laminar tracer to the `generateText`, or `streamText`, or any other `generate*` calls.
@@ -29,38 +72,5 @@ const { text } = await generateText({
   },
 });
 ```
-</Step>
-<Step title="Initialize Laminar">
-<Tabs>
-<Tab title="Next.js">
-In Next.js, place `Laminar.initialize` in the `instrumentation.ts` file.
-
-```typescript {3-4, 6-8} instrumentation.ts
-export async function register() {
-  // prevent this from running in the edge runtime
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const { Laminar } = await import('@lmnr-ai/lmnr');
-
-    Laminar.initialize({
-      projectApiKey: process.env.LMNR_API_KEY,
-    });
-  }
-}
-```
-</Tab>
-<Tab title="Node.js">
-In Node.js, place `Laminar.initialize` in the entry point to your application.
-
-This must be done once, in an entry point of your application after any other tracing SDK initialization.
-
-```javascript
-import { Laminar } from '@lmnr-ai/lmnr';
-
-Laminar.initialize({
-  projectApiKey: process.env.LMNR_API_KEY,
-});
-```
-</Tab>
-</Tabs>
 </Step>
 </Steps>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `next.config.ts` update instructions to Next.js docs for Laminar integration due to OpenTelemetry dependency.
> 
>   - **Configuration**:
>     - Add instructions to update `next.config.ts` in `guides/nextjs.mdx`, `tracing/integrations/nextjs.mdx`, and `tracing/integrations/vercel-ai-sdk.mdx` to include `serverExternalPackages: ['@lmnr-ai/lmnr']`.
>     - Explain necessity due to Laminar's dependency on OpenTelemetry and Node.js-specific functionality.
>   - **Documentation**:
>     - Reorder steps in `tracing/integrations/vercel-ai-sdk.mdx` to place "Update your AI SDK calls" after "Initialize Laminar".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 67b0db187f5352f3432cc9997658e0db8f3362f4. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->