### PR TITLE
feat: docs for sdk evaluator scores

### DIFF
--- a/api-reference/evaluators/create-evaluator-score.mdx
+++ b/api-reference/evaluators/create-evaluator-score.mdx
@@ -1,0 +1,8 @@
+---
+title: 'Create Evaluator Score'
+openapi: 'POST /v1/evaluators/score'
+---
+
+### Description
+
+Create a score for a span using either a trace ID or span ID. When using a trace ID, the score will be attached to the root span of that trace. 

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -344,6 +344,54 @@
           }
         }
       }
+    },
+    "/v1/evaluators/score": {
+      "post": {
+        "tags": [
+          "api::evaluators"
+        ],
+        "operationId": "create_evaluator_score",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateEvaluatorScoreRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Evaluator score created successfully"
+          },
+          "400": {
+            "description": "Bad request. Cannot parse the JSON payload into a valid request."
+          },
+          "401": {
+            "description": "Unauthorized. Project API key is invalid.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": "Invalid project API key."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No matching spans found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": "No matching spans found"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -450,7 +498,7 @@
             "description": "Unique datapoint ID. If not specified, a UUID v4 will be generated."
           },
           "data": {
-            "description": "Input data of the datapoint. Can be any JSON value.",
+            "description": "Input data of the datapoint. Can be any JSON value."
           },
           "index": {
             "type": "integer",
@@ -520,6 +568,103 @@
             "description": "Updated scores for the datapoint as key-value pairs."
           }
         }
+      },
+      "CreateEvaluatorScoreBase": {
+        "type": "object",
+        "required": ["name", "score", "source"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the evaluator score"
+          },
+          "score": {
+            "type": "number",
+            "description": "The score value (float)"
+          },
+          "source": {
+            "type": "string",
+            "enum": ["Code", "Evaluator"],
+            "description": "Source of the score"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Additional metadata for the score",
+            "nullable": true
+          }
+        }
+      },
+      "CreateEvaluatorScoreRequestWithTraceId": {
+        "type": "object",
+        "required": ["name", "score", "source", "traceId"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the evaluator score"
+          },
+          "score": {
+            "type": "number",
+            "description": "The score value (float)"
+          },
+          "source": {
+            "type": "string",
+            "enum": ["Code", "Evaluator"],
+            "description": "Source of the score"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Additional metadata for the score",
+            "nullable": true
+          },
+          "traceId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The trace ID to score (will be attached to root span)"
+          }
+        }
+      },
+      "CreateEvaluatorScoreRequestWithSpanId": {
+        "type": "object",
+        "required": ["name", "score", "source", "spanId"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the evaluator score"
+          },
+          "score": {
+            "type": "number",
+            "description": "The score value (float)"
+          },
+          "source": {
+            "type": "string",
+            "enum": ["Code", "Evaluator"],
+            "description": "Source of the score"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Additional metadata for the score",
+            "nullable": true
+          },
+          "spanId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The span ID to score"
+          }
+        }
+      },
+      "CreateEvaluatorScoreRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CreateEvaluatorScoreRequestWithTraceId",
+            "description": "Create evaluator score with trace ID"
+          },
+          {
+            "$ref": "#/components/schemas/CreateEvaluatorScoreRequestWithSpanId",
+            "description": "Create evaluator score with span ID"
+          }
+        ]
       },
       "AgentChatMessageContentBlockText": {
         "type": "object",

--- a/docs.json
+++ b/docs.json
@@ -98,7 +98,8 @@
                 "group": "Online Evaluators",
                 "pages": [
                   "evaluations/online-evaluators/introduction",
-                  "evaluations/online-evaluators/quick-start"
+                  "evaluations/online-evaluators/scoring-with-hosted-evaluators",
+                  "evaluations/online-evaluators/scoring-with-sdk"
                 ]
               }
             ]
@@ -165,6 +166,12 @@
               "api-reference/evals/init_eval",
               "api-reference/evals/save_eval_datapoints",
               "api-reference/evals/update_eval_datapoint"
+            ]
+          },
+          {
+            "group": "Evaluators - API",
+            "pages": [
+              "api-reference/evaluators/create-evaluator-score"
             ]
           }
         ]

--- a/evaluations/online-evaluators/introduction.mdx
+++ b/evaluations/online-evaluators/introduction.mdx
@@ -16,6 +16,25 @@ The core concept:
 2. **Span Path Registration**: Each evaluator is registered to a specific **span path** - a unique identifier that corresponds to a particular LLM function or call location in your code.
 
 3. **Automatic Execution**: Once registered, evaluators run automatically whenever a span matches their registered path. The evaluator score is immediately attached to the span.
+
+## Two Ways to Produce Evaluator Scores
+
+There are two main approaches to generating evaluator scores in Laminar:
+
+### 1. Hosted Evaluators (Automated)
+Create custom Python functions that run automatically on our platform. These evaluators:
+- Execute automatically when spans match their registered path
+- Require no additional code in your application
+- Are managed and hosted by Laminar
+
+### 2. SDK Scoring (Programmatic)
+Create scores programmatically using our SDK or REST API. This approach:
+- Gives you full control over when and how scores are created
+- Allows integration with your existing evaluation pipeline
+- Supports custom scoring logic that runs in your environment
+
+Both approaches result in the same evaluator scores being attached to your spans, visible in the Laminar dashboard for analysis and monitoring.
+
 ## Getting Started
 
 1. **Go to the Evaluators page** in your Laminar dashboard

--- a/evaluations/online-evaluators/scoring-with-hosted-evaluators.mdx
+++ b/evaluations/online-evaluators/scoring-with-hosted-evaluators.mdx
@@ -1,6 +1,6 @@
 ---
-sidebarTitle: Quick Start
-title: Quick Start to Online Evaluators
+sidebarTitle: Scoring with Hosted Evaluators
+title: Scoring with Hosted Evaluators
 description: Step-by-step examples of setting up online evaluators in Laminar
 ---
 
@@ -46,7 +46,9 @@ def keyword_checker(input):
     return min(keyword_count / len(important_keywords), 1.0)
 ```
 
-![Create evaluator function](/images/evaluations/online-evaluators/create-evaluator-function.png)
+<Frame>
+  <img src="/images/evaluations/online-evaluators/create-evaluator-function.png" alt="Create evaluator function" />
+</Frame>
 
 </Step>
 <Step title="3. Test Your Evaluator">
@@ -60,20 +62,26 @@ Use the test interface to verify your evaluator works correctly with sample inpu
 }
 ```
 
-![Test evaluator](/images/evaluations/online-evaluators/test.png)
+<Frame>
+  <img src="/images/evaluations/online-evaluators/test.png" alt="Test evaluator" />
+</Frame>
 
 </Step>
 <Step title="4. Register to Span Path">
 
 Navigate to your traces, find a span representing the LLM call you want to evaluate, and register your evaluator to that specific span path by clicking evaluators on span view.
 
-![Register to span path](/images/evaluations/online-evaluators/span-path.png)
+<Frame>
+  <img src="/images/evaluations/online-evaluators/span-path.png" alt="Register to span path" />
+</Frame>
 
 </Step>
 <Step title="5. Verify Automatic Execution">
 
 After registration, new spans on that path will automatically trigger your evaluator. Check the span details to see the attached evaluation scores.
-![Verify execution](/images/evaluations/online-evaluators/score.png)
+<Frame>
+  <img src="/images/evaluations/online-evaluators/score.png" alt="Verify execution - evaluator scores displayed in span" />
+</Frame>
 
 </Step>
-</Steps>
+</Steps> 

--- a/evaluations/online-evaluators/scoring-with-sdk.mdx
+++ b/evaluations/online-evaluators/scoring-with-sdk.mdx
@@ -1,0 +1,121 @@
+---
+title: 'Scoring with SDK'
+sidebarTitle: 'Scoring with SDK'
+description: 'Programmatically create evaluator scores using our SDK'
+---
+
+## Create Evaluator Score
+
+Create a score for a span using either a trace ID or span ID. When using a trace ID, the score will be attached to the root span of that trace.
+
+### Code Examples
+
+<CodeGroup>
+
+```typescript TypeScript
+import { LaminarClient, Laminar } from "@lmnr-ai/laminar";
+
+const laminarClient = new LaminarClient({
+  apiKey: "your-project-api-key"
+});
+
+// First, capture your LLM calls
+await laminarClient.observe({
+  name: "chat_completion",
+  input: { messages: [...] },
+  output: { content: "AI response" }
+});
+
+// IMPORTANT: Flush data to ensure it reaches the backend
+await laminarClient.flush();
+
+// Score by trace ID (attaches to root span)
+const traceId = Laminar.getTraceId();
+if (!traceId) {
+  throw new Error("No active trace found");
+}
+
+await laminarClient.evaluators.score({
+  name: "quality",
+  traceId: traceId,
+  score: 0.95,
+  metadata: { model: "gpt-4" }
+});
+
+// Score by span ID 
+// IMPORTANT: This code must be run after span is already recorded
+// In production, ensure this runs later or add sleep to ensure span reaches backend
+await new Promise(resolve => setTimeout(resolve, 1000));
+
+const spanContext = Laminar.getLaminarSpanContext();
+if (!spanContext) {
+  throw new Error("No active span found");
+}
+
+await laminarClient.evaluators.score({
+  name: "relevance", 
+  spanId: spanContext.spanId,
+  score: 0.87
+});
+```
+
+```python Python
+from laminar import LaminarClient, Laminar
+import asyncio
+
+laminar_client = LaminarClient(api_key="your-project-api-key")
+
+# First, capture your LLM calls
+with laminar_client.observe("chat_completion") as span:
+    span.set_input({"messages": [...]})
+    # Your LLM call here
+    span.set_output({"content": "AI response"})
+
+# IMPORTANT: Flush data to ensure it reaches the backend
+await laminar_client.flush()
+
+# Score by trace ID (attaches to root span)
+trace_id = Laminar.get_trace_id()
+if not trace_id:
+    raise ValueError("No active trace found")
+
+await laminar_client.evaluators.score(
+    name="quality",
+    trace_id=trace_id, 
+    score=0.95,
+    metadata={"model": "gpt-4"}
+)
+
+# Score by span ID
+# IMPORTANT: This code must be run after span is already recorded
+# In production, ensure this runs later or add sleep to ensure span reaches backend
+await asyncio.sleep(1)
+
+span_context = Laminar.get_laminar_span_context()
+if not span_context:
+    raise ValueError("No active span found")
+
+await laminar_client.evaluators.score(
+    name="relevance",
+    span_id=span_context.span_id,
+    score=0.87
+)
+```
+
+</CodeGroup>
+
+## Viewing Scores in UI
+
+When you create evaluator scores, they will appear in your Laminar dashboard attached to the corresponding spans:
+
+<Frame>
+    <img src="/images/evaluations/online-evaluators/score.png" alt="Evaluator scores displayed in span details" />
+</Frame>
+
+## API Reference
+
+For detailed API specifications including request/response schemas, visit:
+
+<Card title="Create Evaluator Score" icon="file" href="/api-reference/evaluators/create-evaluator-score">
+  Create scores for spans using trace ID or span ID
+</Card>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation and API support for creating evaluator scores using hosted evaluators and SDK methods.
> 
>   - **Documentation**:
>     - Adds `create-evaluator-score.mdx` for creating evaluator scores using trace ID or span ID.
>     - Updates `introduction.mdx` to describe two methods for generating evaluator scores: hosted evaluators and SDK scoring.
>     - Renames `quick-start.mdx` to `scoring-with-hosted-evaluators.mdx` and updates content to guide setting up hosted evaluators.
>     - Adds `scoring-with-sdk.mdx` to guide programmatic score creation using SDK.
>   - **API**:
>     - Adds `/v1/evaluators/score` endpoint to `openapi.json` for creating evaluator scores.
>     - Defines request schemas `CreateEvaluatorScoreRequestWithTraceId` and `CreateEvaluatorScoreRequestWithSpanId` in `openapi.json`.
>   - **Navigation**:
>     - Updates `docs.json` to include new evaluator score documentation under "Evaluators - API" and "Online Evaluators" sections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 332e3204a3c836ddb8cb476b159c5d30367844c0. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->