### PR TITLE
update coexisting with vercel otel

### DIFF
--- a/tracing/integrations/vercel-ai-sdk.mdx
+++ b/tracing/integrations/vercel-ai-sdk.mdx
@@ -554,15 +554,20 @@ If you already register a tracer provider with `@vercel/otel`, do not call `Lami
 import { registerOTel } from '@vercel/otel';
 
 export async function register() {
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const { LaminarSpanProcessor, initializeLaminarInstrumentations } =
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { registerTelemetry } = await import("ai");
+    const { initializeLaminarInstrumentations, LaminarAiSdkTelemetry } =
       await import('@lmnr-ai/lmnr');
 
+    // Next.js telemetry
     registerOTel({
       serviceName: 'my-service',
-      spanProcessors: [new LaminarSpanProcessor()],
       instrumentations: initializeLaminarInstrumentations(),
     });
+
+    // Laminar AI SDK telemetry. Or `Laminar.initialize()`
+    // for AI SDK before v7.
+    registerTelemetry(new LaminarAiSdkTelemetry());
   }
 }
 ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to an integration guide; no runtime or security impact.
> 
> **Overview**
> Updates the **Coexisting with @vercel/otel** example in `vercel-ai-sdk.mdx` so it matches the AI SDK v7 setup instead of wiring `LaminarSpanProcessor` through `registerOTel`.
> 
> The sample now keeps `@vercel/otel` for Next.js telemetry with `initializeLaminarInstrumentations()` only, and registers Laminar AI SDK tracing separately via `registerTelemetry(new LaminarAiSdkTelemetry())`, with a note that older AI SDK versions can still use `Laminar.initialize()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a06a95c55c50cbe31253ed2b2693f22a7a6c2258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->