### PR TITLE
docs: note registerAiSdkTelemetry() shorthand for AI SDK v7

### DIFF
--- a/tracing/integrations/vercel-ai-sdk.mdx
+++ b/tracing/integrations/vercel-ai-sdk.mdx
@@ -59,6 +59,18 @@ registerTelemetry(new LaminarAiSdkTelemetry());
 
 `new LaminarAiSdkTelemetry()` initializes Laminar for you (it calls `Laminar.initialize()` internally if Laminar isn't already initialized), so you don't need a separate `Laminar.initialize()` call. Pass options to the constructor to configure it: see [Configure the integration](#configure-the-integration).
 
+<Note>
+`@lmnr-ai/lmnr` also exports `registerAiSdkTelemetry()`, a one-line equivalent that registers the same integration without importing `registerTelemetry` from `ai`:
+
+```typescript
+import { registerAiSdkTelemetry } from '@lmnr-ai/lmnr';
+
+registerAiSdkTelemetry(); // same as registerTelemetry(new LaminarAiSdkTelemetry())
+```
+
+It takes the same options object as `LaminarAiSdkTelemetry` (including `laminarOptions`). Reach for it when you want to register telemetry before the AI SDK is loaded, or to keep the import surface to a single package.
+</Note>
+
 </Step>
 <Step title="Use the AI SDK as usual">
 


### PR DESCRIPTION
## What

The Vercel AI SDK integration page already documents the v7 setup as `registerTelemetry(new LaminarAiSdkTelemetry())`. This adds a short `<Note>` under that step pointing out that `@lmnr-ai/lmnr` also exports `registerAiSdkTelemetry()` — a one-line equivalent that registers the same integration **without importing `registerTelemetry` from `ai`**.

## Why

`registerAiSdkTelemetry()` is the form used in practice when you want to register telemetry *before* the AI SDK module is loaded (its whole reason for existing, per the SDK's own docstring: it mirrors `registerTelemetry(...)` but avoids a runtime import of `ai`), or to keep the import surface to a single package. It takes the same options object as `LaminarAiSdkTelemetry` (including `laminarOptions`). It wasn't mentioned anywhere on the page.

## Scope

One additive `<Note>` in `tracing/integrations/vercel-ai-sdk.mdx`. No change to the canonical `registerTelemetry(new LaminarAiSdkTelemetry())` path. Verified `registerAiSdkTelemetry` is a current (non-deprecated) export of `@lmnr-ai/lmnr@0.8.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or API behavior changes.
> 
> **Overview**
> Adds a **`<Note>`** under the AI SDK v7 “Register Laminar telemetry” step in `vercel-ai-sdk.mdx` describing **`registerAiSdkTelemetry()`** from `@lmnr-ai/lmnr` as a one-line alternative to `registerTelemetry(new LaminarAiSdkTelemetry())` that avoids importing `registerTelemetry` from `ai`.
> 
> The note includes a short code sample and states that it accepts the same options as `LaminarAiSdkTelemetry` (including `laminarOptions`), and when to prefer it (register before the AI SDK loads, single-package imports). The canonical `registerTelemetry` path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 992a20c77a982f0b86cf83cf93eea7297e13e620. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->