### PR TITLE
docs: track CLI commands as debugger session blocks

### DIFF
--- a/debugger/introduction.mdx
+++ b/debugger/introduction.mdx
@@ -36,7 +36,7 @@ Three primitives make the loop work:
 
 - **Sessions** group everything from one investigation. The first `LMNR_DEBUG=true` run starts a session and writes `.lmnr/debug-session.json`; every later run in the same directory (or any subdirectory) rejoins it automatically, so neither you nor the agent copies a session id between runs.
 - **Replay** is what makes a turn fast. Rerunning against a recorded trace serves cached LLM responses up to the boundary you pick and runs everything past it live, so you only pay for the calls your change actually touched. See [how caching works](/debugger/caching).
-- **Blocks** are what a session contains: an ordered timeline of runs (traces), evaluations, and notes, sorted by time. The UI renders the same timeline the CLI prints with [`lmnr-cli debug session summary`](/platform/cli#debug-session-summary), so a human and a coding agent read the same story.
+- **Blocks** are what a session contains: an ordered timeline of runs (traces), evaluations, notes, and CLI commands the agent ran (like a `sql query` or `ask`), sorted by time. The UI renders the same timeline the CLI prints with [`lmnr-cli debug session summary`](/platform/cli#debug-session-summary), so a human and a coding agent read the same story.
 
 ## What's next
 

--- a/debugger/process.mdx
+++ b/debugger/process.mdx
@@ -9,7 +9,7 @@ This is the loop your coding agent runs for you. With the [Laminar skill](https:
 
 Watch your agent work from the Laminar UI while it drives the loop from the terminal. Open **Debugger** in your project and select the session, or click the `debugger_url` the SDK prints (it opens automatically when a debug run starts).
 
-A session is a timeline of blocks: runs (traces), evaluations, and notes, interleaved by time. The view streams every block live as your coding agent works. Each run renders Laminar's auto-extracted user inputs, LLM turns, tool calls, and collapsed sub-agent cards. Evals render as cards with per-score averages, and notes render as markdown between them, so you can follow the agent's reasoning in real time.
+A session is a timeline of blocks: runs (traces), evaluations, notes, and CLI commands the agent ran, interleaved by time. The view streams every block live as your coding agent works. Each run renders Laminar's auto-extracted user inputs, LLM turns, tool calls, and collapsed sub-agent cards. Evals render as cards with per-score averages, notes render as markdown between them, and tracked commands render as terminal-style rows, so you can follow the agent's reasoning in real time.
 
 <Frame>
   <img src="/images/debugger-session-view.png" alt="Debugger session timeline showing a note with a span reference, a replay run, an eval card with per-score results, and a closing note" />
@@ -90,7 +90,7 @@ npx lmnr-cli sql query "
   FROM traces
   WHERE simpleJSONExtractString(metadata, 'rollout.session_id') = '<session-id>'
   ORDER BY start_time DESC
-  LIMIT 10"
+  LIMIT 10" --reasoning "listing this session's runs to find the failing trace"
 ```
 
 Locate the bad span:
@@ -100,10 +100,12 @@ npx lmnr-cli sql query "
   SELECT span_id, name, span_type, start_time, status
   FROM spans
   WHERE trace_id = '<trace-id>'
-  ORDER BY start_time ASC"
+  ORDER BY start_time ASC" --reasoning "finding the LLM call before the buggy one to set the replay boundary"
 ```
 
 `span_type` is `LLM`, `TOOL`, `DEFAULT`, or `CACHED` (a replayed call in a replay run). Find the LLM call **before** the buggy one; its `span_id` is the replay boundary you'll pass as `LMNR_DEBUG_CACHE_UNTIL`.
+
+Every `sql query` (and `ask`) run in a directory with an active debug session is recorded into that session as a `command` block, so a reviewer sees what the agent investigated. Use `--reasoning "<why you're running this>"` to attach a short explanation of the command's intent; it renders in the UI on the command block (and in the [session summary](#6-re-orient-with-a-session-summary)), so a human watching the session can follow the agent's reasoning without reading the raw query. Keep it to a short phrase (about 15 words). Pass `--no-track` (or set `LMNR_NO_COMMAND_TRACKING=1`) to skip recording a command.
 
 Run `npx lmnr-cli sql schema` to see all available tables.
 
@@ -158,13 +160,15 @@ npx lmnr-cli debug session summary
 npx lmnr-cli debug session summary --json
 ```
 
-This defaults to the current session; pass `--session-id <session-id>` for another. Output is one entry per block, oldest first: traces and evals print as self-closing tags you can feed into SQL queries, and notes print as their raw markdown.
+This defaults to the current session; pass `--session-id <session-id>` for another. Output is one entry per block, oldest first: traces and evals print as self-closing tags you can feed into SQL queries, commands print as `<command>` tags carrying their exit code and any `--reasoning`, and notes print as their raw markdown.
 
 ```text
 <trace id="…"/>
 
 ## Testing the length cap
 Replaying calls 1-3, running call 4 live with the new cap.
+
+<command exitCode="0" reasoning="finding the LLM call before the buggy one to set the replay boundary">sql query SELECT span_id, name, span_type FROM spans WHERE trace_id = '…'</command>
 
 <trace id="…"/>
 

--- a/platform/cli.mdx
+++ b/platform/cli.mdx
@@ -255,16 +255,53 @@ lmnr-cli debug session set-name "Fix report length" --session-id <session-id>
 
 ### debug session summary
 
-Print the debug session's full timeline, oldest first: every run, evaluation, and note. Use this to re-orient in an ongoing session after a context reset. Defaults to the current session; pass `--session-id` for another.
+Print the debug session's full timeline, oldest first: every run, evaluation, note, and tracked command. Use this to re-orient in an ongoing session after a context reset. Defaults to the current session; pass `--session-id` for another.
 
 ```bash
 lmnr-cli debug session summary
 lmnr-cli debug session summary --session-id <session-id> --json
 ```
 
-Traces and evaluations print as self-closing `<trace id="..."/>` and `<evaluation id="..."/>` tags you can feed into SQL queries; notes print as their raw markdown. With `--json`, the output is an array of `{"id","createdAt","type","content"}` blocks.
+Traces and evaluations print as self-closing `<trace id="..."/>` and `<evaluation id="..."/>` tags you can feed into SQL queries; [tracked commands](#tracking-cli-commands-in-the-debugger) print as `<command exitCode="..." reasoning="...">...</command>` tags; notes print as their raw markdown. With `--json`, the output is an array of `{"id","createdAt","type","content"}` blocks.
 
 See [Debugger](/debugger/process) for the full record/replay process.
+
+## Tracking CLI commands in the debugger
+
+When a debug session is active in the current directory (any `LMNR_DEBUG=true` run has written `.lmnr/debug-session.json`), your investigative commands are recorded into that session automatically. A reviewer watching the session then sees exactly what the agent asked, not just the runs and notes around it.
+
+Two commands are tracked: [`sql query`](#query-data-with-sql) and [`ask`](#ask-the-agent). Each tracked run becomes a `command` block in the session timeline, carrying:
+
+- The command and its arguments (the raw SQL or the raw question).
+- The exit code.
+- The captured stdout/stderr output.
+
+The block renders as a terminal-style row in the session view (red-accented when the command exited non-zero) and as a `<command>` tag in [`debug session summary`](#debug-session-summary). Tracking is best-effort: it never changes a command's output or exit code, and it stays silent on a normal run.
+
+### Explain the intent with `--reasoning`
+
+Pass `--reasoning "<why you're running this>"` to attach a short explanation to the command block. It shows in the UI on the block (and in the session summary), so a human following the session understands *why* the agent ran a query without reading the raw SQL. Keep it to a short phrase, about 15 words.
+
+```bash
+lmnr-cli sql query "SELECT status, count(*) FROM traces GROUP BY status" \
+  --reasoning "checking how many runs errored in this session"
+
+lmnr-cli ask "why did the most recent run fail?" \
+  --reasoning "triaging the failure before editing the prompt"
+```
+
+<Note>
+`--reasoning` is recorded only when a debug session is active in the directory. With no active session the flag is ignored and the CLI warns you; start one with `lmnr-cli debug session new`.
+</Note>
+
+### Disable tracking
+
+Tracking is on by default whenever a session is active. Turn it off for a single command with `--no-track`, or for the whole shell by setting `LMNR_NO_COMMAND_TRACKING=1`:
+
+```bash
+lmnr-cli sql query "SELECT 1" --no-track      # this command only
+export LMNR_NO_COMMAND_TRACKING=1             # every command in this shell
+```
 
 ## Piping and agent-friendly output
 


### PR DESCRIPTION
## What

The CLI now records investigative `sql query` / `ask` runs into the active debug session as `command` blocks, and the debugger session view renders them (lmnr [#2116](https://github.com/lmnr-ai/lmnr/pull/2116), lmnr-ts [#282](https://github.com/lmnr-ai/lmnr-ts/pull/282)). Each command block can carry an agent-supplied `--reasoning` explanation that renders in the UI on the block. This PR reflects that in the debugger docs.

## Changes

- **`debugger/introduction.mdx`** — the "Blocks" primitive now lists CLI commands (a `sql query` or `ask`) alongside runs, evals, and notes.
- **`debugger/process.mdx`**
  - Session-view intro block list now includes tracked commands.
  - **Inspect with SQL** (step 3): both `sql query` examples now pass `--reasoning "<intent>"`, with a paragraph explaining that tracked commands are recorded into the session as `command` blocks and that `--reasoning` attaches a short intent string shown in the UI (plus the `--no-track` / `LMNR_NO_COMMAND_TRACKING` opt-out).
  - Session summary (step 6): describes and shows the new `<command>` tag with its exit code and reasoning.

## Verification

- Loaded both edited pages in `mintlify dev` (both return 200, no frontmatter/parse errors).
- No em dashes or banned marketing words in the diff.
- `--reasoning` / `--no-track` / `LMNR_NO_COMMAND_TRACKING` and the `<command exitCode=... reasoning=...>` summary format verified against the shipped CLI source (`packages/lmnr-cli/src/utils/track-command.ts`, `src/index.ts`, `src/commands/debug/index.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or data-handling impact.
> 
> **Overview**
> Documents that **`sql query`** and **`ask`** runs are recorded as **`command` blocks** in an active debug session, alongside runs, evals, and notes.
> 
> **`debugger/introduction.mdx`** and **`debugger/process.mdx`** now describe tracked CLI commands in the session timeline and UI (terminal-style rows). Step 3 adds **`--reasoning`** on the SQL examples plus opt-out via **`--no-track`** / **`LMNR_NO_COMMAND_TRACKING`**. Step 6’s session summary documents the **`<command>`** tag format.
> 
> **`platform/cli.mdx`** adds **Tracking CLI commands in the debugger**: what gets stored (args, exit code, output), **`--reasoning`**, and how to disable tracking; **`debug session summary`** is updated to mention command blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 599af352a692a13e575f2db032f4275a1dbb1b83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->