### PR TITLE
docs: Pi extension integration page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -33,6 +33,7 @@
                   "tracing/integrations/gemini",
                   "tracing/integrations/claude-code",
                   "tracing/integrations/codex",
+                  "tracing/integrations/pi",
                   "tracing/integrations/claude-agent-sdk",
                   "tracing/integrations/openai-agents-sdk",
                   "tracing/integrations/opencode",

--- a/tracing/integrations/overview.mdx
+++ b/tracing/integrations/overview.mdx
@@ -75,6 +75,9 @@ Multi-step agents, tool calls, and subagents render as a transcript instead of a
   <Card title="Codex" href="/tracing/integrations/codex">
     Trace OpenAI Codex CLI sessions with a one-command plugin install.
   </Card>
+  <Card title="Pi" href="/tracing/integrations/pi">
+    Trace Pi coding agent runs with a one-command extension install.
+  </Card>
   <Card title="Claude Agent SDK" href="/tracing/integrations/claude-agent-sdk">
     Trace Claude Agent SDK runs and subagents.
   </Card>

--- a/tracing/integrations/pi.mdx
+++ b/tracing/integrations/pi.mdx
@@ -1,0 +1,99 @@
+---
+title: Pi Extension
+sidebarTitle: Pi
+---
+
+## Overview
+
+The Pi extension traces every local [Pi](https://pi.dev) coding agent session: each agent run becomes a full trace with its LLM calls and tool executions, sent to Laminar. Runs from the same Pi session are grouped into one Laminar [session](/tracing/structure/sessions).
+
+The extension subscribes to Pi's own lifecycle events, so spans open and close in process. Traces appear in Laminar while the run is still going.
+
+## Install
+
+<Steps>
+<Step title="Run the installer">
+
+```bash
+npx lmnr-cli@latest plugin add pi
+```
+
+The CLI logs you in (browser device flow), lets you pick the Laminar project that should receive your Pi traces, mints a project API key named after the extension and your machine, writes it to `~/.config/lmnr/pi-extension.json`, and installs the extension with `pi install npm:@lmnr-ai/pi-extension`.
+
+<Tip>
+Pick a dedicated project for coding-agent traces so they don't mix with your application's traces. The setup is global and directory-independent: it never touches `.lmnr/project.json` or your `.env`.
+</Tip>
+
+</Step>
+<Step title="Restart Pi">
+
+Pi loads extensions at startup, so restart it to activate the extension.
+
+</Step>
+<Step title="Use Pi as usual">
+
+Every agent run becomes a trace in the project you picked. Open the Laminar dashboard to watch them land in realtime.
+
+</Step>
+</Steps>
+
+<Note>
+**Self-hosting Laminar?** The same command works against your instance: pass your frontend URL (the auth issuer) and your API URL, including the API port:
+
+```bash
+npx lmnr-cli@latest plugin add pi \
+  --frontend-url https://laminar.example.com \
+  --base-url https://api.laminar.example.com
+```
+</Note>
+
+### Manual install
+
+If you'd rather not use `lmnr-cli`, install the package with Pi's own command and set the key in your environment:
+
+```bash
+pi install npm:@lmnr-ai/pi-extension
+export LMNR_PROJECT_API_KEY="..."
+```
+
+Get a key from the Laminar dashboard under **Settings → Project API Keys** (create a dedicated key so it's clear it belongs to the extension).
+
+`pi install` adds the package to your global settings (`~/.pi/agent/settings.json`) and installs it under `~/.pi/agent/npm/`. Add `-l` to scope it to the current project (`.pi/settings.json`) instead. You can also add the package to `settings.json` by hand:
+
+```json ~/.pi/agent/settings.json
+{ "packages": ["npm:@lmnr-ai/pi-extension"] }
+```
+
+## What you get
+
+One trace covers one Pi agent run, with an LLM span per turn and a tool span per tool call. Spans open on Pi's start events and close on its end events, so the trace fills in as the run progresses.
+
+Each LLM span carries the model, the provider, the finish reason, and the full input and output messages for that turn, so the run reads end to end in [transcript view](/platform/viewing-traces#transcript-view). Token counts, cache reads, and cost come straight from Pi's own usage numbers, which are accurate for every provider and model Pi supports. Tool spans carry the tool name, its arguments, and its result, and are marked as errors when the tool fails.
+
+The root span records Pi's session id and the working directory. Use the session id to group a whole conversation, and the working directory to tell one repository's runs from another's.
+
+## Configuration
+
+The extension reads its config from `~/.config/lmnr/pi-extension.json`, written by `lmnr-cli plugin add pi`:
+
+```json
+{ "projectApiKey": "...", "baseUrl": "https://api.lmnr.ai" }
+```
+
+`projectApiKey` is required. `baseUrl` is optional and defaults to `https://api.lmnr.ai`; self-hosters set it to their instance's API URL (for example `http://localhost:8000`).
+
+These environment variables override the file when set, which is handy for CI or a shell you already have configured. The extension is fail-open: with no key from either source it disables itself and Pi runs untouched.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `LMNR_PROJECT_API_KEY` | config file | Laminar project API key. |
+| `LMNR_BASE_URL` | config file, else `https://api.lmnr.ai` | Laminar API base URL, for self-hosted deployments. |
+| `LMNR_USER_ID` | — | User id to attach to every trace. |
+| `LMNR_MAX_CHARS` | `20000` | Character cap for span input and output values. |
+| `LMNR_DEBUG` | — | Set to `true` to attach runs to a debugger session and write a log file. |
+
+## Debugger sessions
+
+Set `LMNR_DEBUG=true` and each run also joins a Laminar [debugger session](/debugger/introduction), so you can inspect and replay it. The SDK resolves the session id in this order: `LMNR_DEBUG_SESSION_ID`, then the nearest `.lmnr/debug-session.json` written by `lmnr-cli debug session new`, then a fresh id.
+
+`LMNR_DEBUG=true` also turns on file logging to `~/.pi/agent/lmnr-pi-extension.log`. Pi is a terminal UI, so the extension never writes diagnostics to stdout. Read that file when traces do not arrive.

--- a/tracing/integrations/pi.mdx
+++ b/tracing/integrations/pi.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Pi
 
 ## Overview
 
-The Pi extension traces every local [Pi](https://pi.dev) coding agent session: each agent run becomes a full trace with its LLM calls and tool executions, sent to Laminar. Runs from the same Pi session are grouped into one Laminar [session](/tracing/structure/sessions).
+The Pi extension traces every local [Pi](https://pi.dev) coding agent session: each prompt becomes a full trace with its LLM calls and tool executions, sent to Laminar. Traces from the same Pi session are grouped into one Laminar [session](/tracing/structure/sessions).
 
 The extension subscribes to Pi's own lifecycle events, so spans open and close in process. Traces appear in Laminar while the run is still going.
 
@@ -32,7 +32,7 @@ Pi loads extensions at startup, so restart it to activate the extension.
 </Step>
 <Step title="Use Pi as usual">
 
-Every agent run becomes a trace in the project you picked. Open the Laminar dashboard to watch them land in realtime.
+Every prompt becomes a trace in the project you picked. Open the Laminar dashboard to watch them land in realtime.
 
 </Step>
 </Steps>
@@ -66,9 +66,23 @@ Get a key from the Laminar dashboard under **Settings → Project API Keys** (cr
 
 ## What you get
 
-One trace covers one Pi agent run, with an LLM span per turn and a tool span per tool call. Spans open on Pi's start events and close on its end events, so the trace fills in as the run progresses.
+One trace covers one prompt. Pi can run its agent loop more than once for a single prompt: an auto-retry, an auto-compaction retry, and a queued follow-up each start another pass. Every pass lands in the same trace. Inside it you get one LLM span per model call and one tool span per tool call.
 
-Each LLM span carries the model, the provider, the finish reason, and the full input and output messages for that turn, so the run reads end to end in [transcript view](/platform/viewing-traces#transcript-view). Token counts, cache reads, and cost come straight from Pi's own usage numbers, which are accurate for every provider and model Pi supports. Tool spans carry the tool name, its arguments, and its result, and are marked as errors when the tool fails.
+Spans open when the work starts, not when it finishes. An LLM span opens as Pi hands the request to the model, so its duration is the real call latency.
+
+### What each LLM span reports
+
+**The messages Pi actually sent.** `gen_ai.input.messages` is the list Pi assembled for that call, so a turn shows the full session history: earlier prompts, and the state after a compaction.
+
+**The system prompt**, as a `system` message at the head of every turn. This is the prompt Pi sent, after each extension has had its say.
+
+**The active tool definitions**, as `gen_ai.tool.definitions`: the name, description, and JSON schema of every tool the run can call. Laminar reads these into its tool-definitions column.
+
+**Tokens and cost**, from Pi's own numbers, which are correct for every provider and model Pi supports. Input, output, cache reads, cache writes, reasoning tokens, and Anthropic's one-hour cache-write split all come through. Cache costs fold into the input cost, so the input and output costs add up to the total that Pi reports.
+
+**Errors.** A turn that ends in an error, or that you abort, marks its LLM span failed and carries Pi's error message. The root span is failed when the run's last turn failed, so a successful retry clears it. A tool span is failed when the tool reports an error. Filter on either to find broken runs.
+
+Together with the model, the provider, and the finish reason, that makes each run read end to end in [transcript view](/platform/viewing-traces#transcript-view). Messages use Anthropic-style content blocks, the same shape as every other Laminar integration: reasoning stays its own `thinking` block instead of being folded into the reply, and tool calls and results keep their own blocks. Images appear as `[image <mime type>]` rather than re-embedded payloads.
 
 The root span records Pi's session id and the working directory. Use the session id to group a whole conversation, and the working directory to tell one repository's runs from another's.
 
@@ -82,14 +96,14 @@ The extension reads its config from `~/.config/lmnr/pi-extension.json`, written 
 
 `projectApiKey` is required. `baseUrl` is optional and defaults to `https://api.lmnr.ai`; self-hosters set it to their instance's API URL (for example `http://localhost:8000`).
 
-These environment variables override the file when set, which is handy for CI or a shell you already have configured. The extension is fail-open: with no key from either source it disables itself and Pi runs untouched.
+These environment variables override the file when set, which is handy for CI or a shell you already have configured. The extension is fail-open: with no key from either source it disables itself and Pi runs untouched. Traces are attributed to the identity from `lmnr-cli login` when present; set `LMNR_USER_ID` to override the user id attached to traces.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `LMNR_PROJECT_API_KEY` | config file | Laminar project API key. |
 | `LMNR_BASE_URL` | config file, else `https://api.lmnr.ai` | Laminar API base URL, for self-hosted deployments. |
-| `LMNR_USER_ID` | — | User id to attach to every trace. |
-| `LMNR_MAX_CHARS` | `20000` | Character cap for span input and output values. |
+| `LMNR_USER_ID` | `lmnr-cli login` identity | User id to attach to every trace. |
+| `LMNR_MAX_CHARS` | `20000` | Character cap for span input and output values. The system prompt gets its own budget of this size, so a turn's input can reach about twice the cap. |
 | `LMNR_DEBUG` | — | Set to `true` to attach runs to a debugger session and write a log file. |
 
 ## Debugger sessions

--- a/tracing/integrations/pi.mdx
+++ b/tracing/integrations/pi.mdx
@@ -70,22 +70,6 @@ One trace covers one prompt. Pi can run its agent loop more than once for a sing
 
 Spans open when the work starts, not when it finishes. An LLM span opens as Pi hands the request to the model, so its duration is the real call latency.
 
-### What each LLM span reports
-
-**The messages Pi actually sent.** `gen_ai.input.messages` is the list Pi assembled for that call, so a turn shows the full session history: earlier prompts, and the state after a compaction.
-
-**The system prompt**, as a `system` message at the head of every turn. This is the prompt Pi sent, after each extension has had its say.
-
-**The active tool definitions**, as `gen_ai.tool.definitions`: the name, description, and JSON schema of every tool the run can call. Laminar reads these into its tool-definitions column.
-
-**Tokens and cost**, from Pi's own numbers, which are correct for every provider and model Pi supports. Input, output, cache reads, cache writes, reasoning tokens, and Anthropic's one-hour cache-write split all come through. Cache costs fold into the input cost, so the input and output costs add up to the total that Pi reports.
-
-**Errors.** A turn that ends in an error, or that you abort, marks its LLM span failed and carries Pi's error message. The root span is failed when the run's last turn failed, so a successful retry clears it. A tool span is failed when the tool reports an error. Filter on either to find broken runs.
-
-Together with the model, the provider, and the finish reason, that makes each run read end to end in [transcript view](/platform/viewing-traces#transcript-view). Messages use Anthropic-style content blocks, the same shape as every other Laminar integration: reasoning stays its own `thinking` block instead of being folded into the reply, and tool calls and results keep their own blocks. Images appear as `[image <mime type>]` rather than re-embedded payloads.
-
-The root span records Pi's session id and the working directory. Use the session id to group a whole conversation, and the working directory to tell one repository's runs from another's.
-
 ## Configuration
 
 The extension reads its config from `~/.config/lmnr/pi-extension.json`, written by `lmnr-cli plugin add pi`:


### PR DESCRIPTION
Documents the Laminar extension for the [Pi coding agent](https://pi.dev), structured like the existing Claude Code and Codex plugin pages.

Depends on:
- lmnr-ai/lmnr-ts#290 — adds the `lmnr-cli plugin add pi` command the page leads with
- lmnr-ai/lmnr-pi-extension#1 — teaches the extension to read the key that command writes

## The page

`tracing/integrations/pi.mdx`, added to `docs.json` and to the Coding agents CardGroup on the integrations overview, after Codex.

- **Install** leads with `npx lmnr-cli@latest plugin add pi`, with a self-hosting `<Note>` and a **Manual install** section covering `pi install npm:@lmnr-ai/pi-extension` plus the `packages` entry in `settings.json`.
- **What you get** describes the trace shape (one trace per agent run, an LLM span per turn, a tool span per tool call) and what each span carries.
- **Configuration** is file-first with the env-var overrides tabled underneath.
- **Debugger sessions** covers `LMNR_DEBUG=true` and the log file.

Content was verified against the extension source rather than its README: `config.ts` for the config surface, `index.ts` for the span shape and the root span's session id and cwd, `attributes.ts` for the LLM span attributes and Pi-supplied cost.

## Testing

`npx mintlify broken-links` clean; the page loads 200 in `mintlify dev` with no frontmatter errors.

## Notes

- Like its Claude Code and Codex siblings, this page is deliberately short and omits the "Track outcomes with Signals" and "Query across traces" sections that the framework integration pages carry.
- The Coding agents CardGroup is now five cards, so the grid has one hanging.
- No `changelog.mdx` entry yet: `@lmnr-ai/pi-extension` is still unpublished on npm, so it would announce something users can't install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)