### PR TITLE
Add Cloud Agent dev environment (Mintlify docs preview)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "Laminar documentation",
+  "install": "npm install -g mintlify --prefix \"$HOME/.npm-global\"",
+  "terminals": [
+    {
+      "name": "mintlify-dev",
+      "command": "export PATH=\"$HOME/.npm-global/bin:$PATH\" && mintlify dev --port 3000",
+      "description": "Mintlify docs preview server on http://localhost:3000 (hot-reloads .mdx/docs.json edits)."
+    }
+  ],
+  "ports": [
+    {
+      "name": "mintlify-dev",
+      "port": 3000
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a committed `.cursor/environment.json` so Cloud Agents on this docs repo boot with a working Mintlify toolchain and a live preview server.

This repo is a Mintlify site (`docs.json`, `.mdx` pages) with no `package.json`; the dev flow is the `mintlify` CLI (per `README.md`). The environment config captures that:

- `install`: `npm install -g mintlify --prefix "$HOME/.npm-global"` — installs the CLI into a user-writable global prefix (the default `-g` prefix is root-owned and fails with `EACCES`; using `--prefix` also avoids the nvm `.npmrc` prefix conflict).
- `terminals`: runs `mintlify dev --port 3000` as a visible, hot-reloading preview server.
- `ports`: exposes `3000`.

## Validation

| Check | Result |
| --- | --- |
| `mintlify dev` serves pages | root 307 → `/overview` 200, `/getting-started` 200 |
| Browser render (Overview, Getting Started, Tracing) | Rendered with sidebar, headings, code blocks, images |
| `mintlify broken-links` | `success no broken links found` |
| Install idempotence | Passed (ran twice, exit 0) |
| Draft environment build (`install` from default image) | SUCCEEDED — mintlify installed, exit 0 |

The Mintlify version installed is `4.2.792` on Node `v22`.

## Notes

- No application code changed — only the environment config was added.
- `mintlify dev` prints a harmless one-time `Run mintlify login in the cli to activate search`; search is a hosted feature and not required for local preview.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e85956f8-f4b3-4b05-8c0d-620a6f689b25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e85956f8-f4b3-4b05-8c0d-620a6f689b25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

